### PR TITLE
🐛 Pihole control bug fix

### DIFF
--- a/src/server/api/routers/dns-hole/router.ts
+++ b/src/server/api/routers/dns-hole/router.ts
@@ -22,7 +22,11 @@ export const dnsHoleRouter = createTRPCRouter({
       const config = getConfig(input.configName);
 
       const applicableApps = config.apps.filter(
-        (app) => app.id && input.appsToChange?.includes(app.id)
+        (app) =>
+          app.id &&
+          app.integration?.type &&
+          input.appsToChange?.includes(app.id) &&
+          ['pihole', 'adGuardHome'].includes(app.integration?.type)
       );
 
       await Promise.all(

--- a/src/tools/server/sdk/pihole/piHole.ts
+++ b/src/tools/server/sdk/pihole/piHole.ts
@@ -62,6 +62,18 @@ export class PiHoleClient {
       );
     }
 
-    return json as PiHoleApiStatusChangeResponse;
+    for(let loops = 0; loops < 10; loops++){
+      const summary = await this.getSummary()
+      if (summary.status === action + 'd'){
+        return json as PiHoleApiStatusChangeResponse;
+      }
+      await new Promise ((resolve) => { setTimeout(resolve, 50)});
+    }
+
+    return Promise.reject(
+      new Error(
+        `Although PiHole received the command, it failed to update it's status: ${json}`
+      )
+    )
   }
 }


### PR DESCRIPTION
### Category
> Bugfix

### Overview
> Based on PR #1306 by @taos15 

#### Premise of the bug
> PiHole sends a response that it toggled itself before it actually did.
> When doing the summary fetch right after, if the Pihole system is too busy, PiHole won't have time to actually update its status.
> So, for a short time, even though the API has responded that the PiHole is toggled, it actually isn't.
> The summary though will always return what state the app actually is in.
> ![image](https://github.com/ajnart/homarr/assets/26098587/c277c001-eeb3-4374-b4f4-e68eeb55e01a)

#### Possible fix 1:
> We can just take the response for granted, trust it and instead of fetching right after, just use the value reported back to change the general status in the app.
> This makes the least amount of calls to the API but relies on the "Trust me Bro" from the API and caching that response.
> Assuming it isn't entirely wrong as the command will be executed at some point, but doing so means that if another toggle is done close after, it may stack the executes which I don't know if it is a good idea.
> ![image](https://github.com/ajnart/homarr/assets/26098587/6f5bd17b-390d-4351-81f9-4733b768cc66)

#### Possible fix 2:
> We can query the summary until it is validated that the pihole internal state actually corresponds to the status we want to assign.
> This makes at most 12 fetches, contrary to the 1 of the first fix or 2 in the current behavior.
> In normal state this will only result in 3 to 4 fetches.
> This makes absolutely sure that the original command only comes back when the status has changed.
> Easiest to implement and the bugfix present in this PR for now.
> ![image](https://github.com/ajnart/homarr/assets/26098587/8be1421e-5664-4797-90f6-1f43d738e670)

#### TLDR
> PiHole API is not great.
> Sends back "Trust me bro it's toggled" but it isn't for a short time.
> That short time can extend enough for the PiHole Control widget to misbehave.
> fix 1: Caching response and trusting a trust me bro that isn't really trustable, but very light on traffic solution.
> fix 2: Traffic heavy loop with timeout that waits for PiHole to actually update and that you can trust.

#### Side notes
> This PR also includes a few UX and code tweaks for the DNS Hole control
> Disabling of the buttons of the DnsHole Control Widget when an update is happening. Serves as visual feedback to the user that they shouldn't (and now also can't) spam the button and that something is happening along the blue dot signaling the same.
> Fixed few typos in the DnsHole Control Widget's code
> Added back the filter to eliminate any apps given that are not PiHole or AdGuard. In case the function gets used somewhere else and is mishandled.